### PR TITLE
Add modules support and fix tests Fixes #1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mre/edgecast
+
+require github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da h1:FjHUJJ7oBW4G/9j1KzlHaXL09LyMVM9rupS39lncbXk=
+github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da/go.mod h1:ks+b9deReOc7jgqp+e7LuFiCBH6Rm5hL32cLcEAArb4=
+github.com/jarcoal/httpmock v0.0.0-20180719183105-8007e27cdb32 h1:hBufcn/i2Petw3NL2331fY81/wWxNt11ks7CkadZAlw=
+github.com/jarcoal/httpmock v0.0.0-20180719183105-8007e27cdb32/go.mod h1:ks+b9deReOc7jgqp+e7LuFiCBH6Rm5hL32cLcEAArb4=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,1 @@
-github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da h1:FjHUJJ7oBW4G/9j1KzlHaXL09LyMVM9rupS39lncbXk=
 github.com/jarcoal/httpmock v0.0.0-20180424175123-9c70cfe4a1da/go.mod h1:ks+b9deReOc7jgqp+e7LuFiCBH6Rm5hL32cLcEAArb4=
-github.com/jarcoal/httpmock v0.0.0-20180719183105-8007e27cdb32 h1:hBufcn/i2Petw3NL2331fY81/wWxNt11ks7CkadZAlw=
-github.com/jarcoal/httpmock v0.0.0-20180719183105-8007e27cdb32/go.mod h1:ks+b9deReOc7jgqp+e7LuFiCBH6Rm5hL32cLcEAArb4=

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,11 @@ package edgecast
 
 import (
 	"fmt"
-	"gopkg.in/jarcoal/httpmock.v1"
 	"io/ioutil"
 	"reflect"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
 )
 
 func TestClient(t *testing.T) {
@@ -46,7 +47,7 @@ func TestClient(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(dataBW, &expectedBW) {
-		t.Errorf("Expected %s (type %#v), got %s (type %#v)", expectedBW, expectedBW, dataBW, dataBW)
+		t.Errorf("Expected %#v, got %#v", expectedBW, dataBW)
 	}
 
 	// Test connection request
@@ -62,7 +63,7 @@ func TestClient(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(dataConn, &expectedConn) {
-		t.Errorf("Expected %s (type %#v), got %s (type %#v)", expectedConn, expectedConn, dataConn, dataConn)
+		t.Errorf("Expected %#v, got %#v", expectedConn, dataConn)
 	}
 
 	// Test cachestatus request


### PR DESCRIPTION
This adds gomodules support. As the dependency is only on the tests I've updated to the lastest version of `jarcoal/httpmock`

2 tests had invalid message because they were using `%s` but the structs did not implement the Stringer interface, so I just removed them as the struct values will be printed on the error message.