### PR TITLE
Add TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+
+# Specify Go versions to test (".x" suffix means latest minor version, "tip" is
+# the latest development version)
+go:
+  - "1.9.x"
+  - "1.10.x"
+  - "1.11.x"
+  - tip
+
+# Allow failures on development version as they can happen due to third party
+# problems. Consider the build successful as soon as all other builds are
+# finished.
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
+
+# Install all dependencies (including dependencies of tests) without installing
+# binaries.
+install:
+  - go get -d -t -v ./...
+
+# Check if gofmt or go vet report any errors then run all tests with the race
+# detector enabled.
+script:
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # edgecast
 
-A golang client for the [Edgecast CDN API](https://www.programmableweb.com/api/edgecast-cdn).  
+[![Build Status](https://travis-ci.org/mre/edgecast.svg?branch=master)](https://travis-ci.org/mre/edgecast)
+
+A golang client for the [Edgecast CDN API](https://www.programmableweb.com/api/edgecast-cdn).
 
 ## Installation
 


### PR DESCRIPTION
Added a configuration file and build badge for TravisCI. It will run test for new commits with go 1.9, 1.10, 1.11 and the latest development version. Also checks if `gofmt` or `go vet` reports any possible improvements.

If you already have Travis set up for your account, just enable it for the repository. Otherwise follow the instructions on their site: https://docs.travis-ci.com/user/getting-started/#to-get-started-with-travis-ci

After merging you can test the setup by adding a new commit or manually triggering a build on the `master` branch.

Fixes #4.